### PR TITLE
Suggested changed to UI README.

### DIFF
--- a/UI/README.md
+++ b/UI/README.md
@@ -5,16 +5,18 @@ The app uses [node-webkit](https://github.com/rogerwang/node-webkit) to provide 
 
 ### How do I get set up? ###
 
-First you will need to install [Node.js](http://nodejs.org/), I suggest using [Homebrew](http://brew.sh/) for this. 
+First you will need to install [Node.js](http://nodejs.org/), I suggest using homebrew via nvm for this. 
 
 ~~~~
-brew install nodejs
+brew install nvm
+nvm install 0.12.0
+nvm use 0.12.0
 ~~~~
 
 Then run the following terminal commands to install node followed by the dependencies used by the app. From the root folder of the source code:
 
 ~~~~
-npm install -g nodewebkit
+npm install -g nw
 npm install -g grunt-cli
 npm install -g sass
 npm install
@@ -28,7 +30,7 @@ Note; `npm` should not require `sudo` to run. If it does (as happened to me) the
 The following terminal command runs the app in the `app` folder. You can terminate it with `ctrl-C`.
 
 ~~~~
-nodewebkit app
+nw app
 ~~~~
 
 #### Configuration ####
@@ -39,7 +41,7 @@ Command 				| Description
 ----------------------- | --------------------------------------------------------------------------------------------------------- 
 `grunt sass`  			| Convert the [sass](http://sass-lang.com/) into the `css` used by the app. 								
 `grunt watch` 			| Watch for changes to the sass files and recompile them automatically. Terminate it with `ctrl-C`. 		
-`grunt minify` 			| Minify assets and place in the `dist` folder for final packaging. Can be tested using `nodewebkit dist`. 	
+`grunt minify` 			| Minify assets and place in the `dist` folder for final packaging. Can be tested using `nw dist`. 	
 `grunt mac-icons`		| Create Mac icon files from `icon/mac/icon.pdf`.															
 `grunt clean`			| Erase temporary files.																					
 


### PR DESCRIPTION
 NVM is the recommended way to install node via brew on osx. This worked much better for me. 

See http://stackoverflow.com/questions/28017374/what-is-the-suggested-way-to-install-brew-node-js-io-js-nvm-npm-on-os-x. 

Also nodewebkit is depreciated in favour of nw.js. nw worked fine for me so unless there's any issues I propose we use this for any future updates? 

'All future releases (of nodewebkit) >= 0.12.0 will be released through nw.' - https://github.com/nwjs/nw.js/blob/nw12/CHANGELOG.md#0120-alpha1--01-15-2015
